### PR TITLE
6/unit testing

### DIFF
--- a/spikemetrics/metrics.py
+++ b/spikemetrics/metrics.py
@@ -231,6 +231,7 @@ def calculate_pc_metrics(spike_clusters,
                          max_spikes_for_cluster,
                          spikes_for_nn,
                          n_neighbors,
+                         min_num_pcs=10,
                          metric_names=None,
                          seed=0, verbose=True):
     assert (num_channels_to_compare % 2 == 1)
@@ -313,7 +314,7 @@ def calculate_pc_metrics(spike_clusters,
 
         all_pcs = np.reshape(all_pcs, (all_pcs.shape[0], pc_features.shape[1] * channels_to_use.size))
 
-        if all_pcs.shape[0] > 10:
+        if all_pcs.shape[0] > min_num_pcs:
 
             if 'isolation_distance' in metric_names or 'l_ratio' in metric_names:
                 isolation_distances[cluster_id], l_ratios[cluster_id] = mahalanobis_metrics(all_pcs, all_labels,

--- a/spikemetrics/metrics.py
+++ b/spikemetrics/metrics.py
@@ -507,7 +507,7 @@ def presence_ratio(spike_train, min_time, max_time, num_bins=100):
 
     h, b = np.histogram(spike_train, np.linspace(min_time, max_time, num_bins))
 
-    return np.sum(h > 0) / num_bins
+    return np.sum(h > 0) / (num_bins - 1)
 
 
 def firing_rate(spike_train, min_time=None, max_time=None):

--- a/spikemetrics/metrics.py
+++ b/spikemetrics/metrics.py
@@ -477,6 +477,8 @@ def isi_violations(spike_train, min_time, max_time, isi_threshold, min_isi=None)
     if min_isi is not None:
         duplicate_spikes = np.where(isis <= min_isi)[0]
         spike_train = np.delete(spike_train, duplicate_spikes + 1)
+    else:
+        min_isi = 0
     
     num_spikes = len(spike_train)
     num_violations = sum(isis < isi_threshold)

--- a/spikemetrics/metrics.py
+++ b/spikemetrics/metrics.py
@@ -490,7 +490,7 @@ def isi_violations(spike_train, min_time, max_time, isi_threshold, min_isi=None)
     return fpRate, num_violations
 
 
-def presence_ratio(spike_train, min_time, max_time, num_bins=101):
+def presence_ratio(spike_train, min_time, max_time, num_bin_edges=101):
     """Calculate fraction of time the unit is present within an epoch.
 
     Inputs:
@@ -498,6 +498,8 @@ def presence_ratio(spike_train, min_time, max_time, num_bins=101):
     spike_train : array of spike times
     min_time : minimum time for potential spikes
     max_time : maximum time for potential spikes
+    num_bin_edges : number of bin edges for histogram
+      - total bins = num_bin_edges - 1
 
     Outputs:
     --------
@@ -505,9 +507,9 @@ def presence_ratio(spike_train, min_time, max_time, num_bins=101):
 
     """
 
-    h, b = np.histogram(spike_train, np.linspace(min_time, max_time, num_bins))
+    h, b = np.histogram(spike_train, np.linspace(min_time, max_time, num_bin_edges))
 
-    return np.sum(h > 0) / (num_bins - 1)
+    return np.sum(h > 0) / (num_bin_edges - 1)
 
 
 def firing_rate(spike_train, min_time=None, max_time=None):

--- a/spikemetrics/metrics.py
+++ b/spikemetrics/metrics.py
@@ -511,16 +511,13 @@ def presence_ratio(spike_train, min_time, max_time, num_bins=100):
 def firing_rate(spike_train, min_time=None, max_time=None):
     """Calculate firing rate for a spike train.
 
-    If no temporal bounds are specified, the first and last spike time are used.
+    If either temporal bound is not specified, the first and last spike time are used by default.
 
     Inputs:
     -------
-    spike_train : numpy.ndarray
-        Array of spike times in seconds
-    min_time : float
-        Time of first possible spike (optional)
-    max_time : float
-        Time of last possible spike (optional)
+    spike_train : array of spike times (in seconds)
+    min_time : time of first possible spike (optional)
+    max_time : time of last possible spike (optional)
 
     Outputs:
     --------
@@ -529,11 +526,13 @@ def firing_rate(spike_train, min_time=None, max_time=None):
 
     """
 
-    if min_time is not None and max_time is not None:
-        duration = max_time - min_time
-    else:
-        duration = np.max(spike_train) - np.min(spike_train)
+    if min_time is None:
+        min_time = np.min(spike_train) 
 
+    if max_time is None:
+        max_time = np.max(spike_train)
+
+    duration = max_time - min_time
     fr = spike_train.size / duration
 
     return fr

--- a/spikemetrics/metrics.py
+++ b/spikemetrics/metrics.py
@@ -490,7 +490,7 @@ def isi_violations(spike_train, min_time, max_time, isi_threshold, min_isi=None)
     return fpRate, num_violations
 
 
-def presence_ratio(spike_train, min_time, max_time, num_bins=100):
+def presence_ratio(spike_train, min_time, max_time, num_bins=101):
     """Calculate fraction of time the unit is present within an epoch.
 
     Inputs:

--- a/spikemetrics/metrics.py
+++ b/spikemetrics/metrics.py
@@ -398,11 +398,15 @@ def calculate_drift_metrics(spike_times,
                             pc_feature_ind,
                             interval_length,
                             min_spikes_per_interval,
+                            vertical_channel_spacing=10,
                             verbose=True):
+
     max_drift = np.zeros((total_units,))
     cumulative_drift = np.zeros((total_units,))
 
-    depths = get_spike_depths(spike_clusters, pc_features, pc_feature_ind)
+    depths = get_spike_depths(spike_clusters, pc_features, pc_feature_ind, vertical_channel_spacing)
+
+    print(depths)
 
     interval_starts = np.arange(np.min(spike_times), np.max(spike_times), interval_length)
     interval_ends = interval_starts + interval_length

--- a/spikemetrics/metrics.py
+++ b/spikemetrics/metrics.py
@@ -4,6 +4,7 @@ import numpy as np
 import pandas as pd
 from collections import OrderedDict
 import math
+import warnings
 
 from sklearn.discriminant_analysis import LinearDiscriminantAnalysis as LDA
 from sklearn.neighbors import NearestNeighbors
@@ -381,7 +382,7 @@ def calculate_silhouette_score(spike_clusters,
 
         for idx2, j in enumerate(cluster_ids):
 
-            if j != i:
+            if j > i:
                 inds = np.in1d(cluster_labels, np.array([i, j]))
                 X = all_pcs[inds, :]
                 labels = cluster_labels[inds]
@@ -389,7 +390,12 @@ def calculate_silhouette_score(spike_clusters,
                 if len(labels) > 2:
                     SS[i, j] = silhouette_score(X, labels)
 
-    return np.nanmin(SS, 0)
+    with warnings.catch_warnings():
+      warnings.simplefilter("ignore")
+      a = np.nanmin(SS, 0)
+      b = np.nanmin(SS, 1)
+
+    return np.array([np.nanmin([a,b]) for a, b in zip(a,b)])
 
 
 def calculate_drift_metrics(spike_times,

--- a/spikemetrics/metrics.py
+++ b/spikemetrics/metrics.py
@@ -553,11 +553,15 @@ def amplitude_cutoff(amplitudes, num_histogram_bins=500, histogram_smoothing_val
     ------
     amplitudes : numpy.ndarray
         Array of amplitudes (don't need to be in physical units)
+    num_histogram_bins : int
+        Number of bins for calculating amplitude histogram
+    histogram_smoothing_value : float
+        Gaussian filter window for smoothing amplitude histogram
 
     Output:
     -------
     fraction_missing : float
-        Fraction of missing spikes (0-0.5)
+        Fraction of missing spikes (ranges between 0 and 0.5)
         If more than 50% of spikes are missing, an accurate estimate isn't possible
 
     """

--- a/spikemetrics/metrics.py
+++ b/spikemetrics/metrics.py
@@ -381,7 +381,7 @@ def calculate_silhouette_score(spike_clusters,
 
         for idx2, j in enumerate(cluster_ids):
 
-            if j > i:
+            if j != i:
                 inds = np.in1d(cluster_labels, np.array([i, j]))
                 X = all_pcs[inds, :]
                 labels = cluster_labels[inds]

--- a/spikemetrics/tests/test_metrics.py
+++ b/spikemetrics/tests/test_metrics.py
@@ -32,4 +32,5 @@ def test_calculate_presence_ratio():
 
 
 def test_calculate_metrics():
+    
     pass

--- a/spikemetrics/tests/test_metrics.py
+++ b/spikemetrics/tests/test_metrics.py
@@ -96,15 +96,11 @@ def test_mahalanobis_metrics():
 
     all_pcs1, all_labels1 = create_ground_truth_pc_distributions([1,-1],[1000, 1000])
     all_pcs2, all_labels2 = create_ground_truth_pc_distributions([1,-2],[1000, 1000]) # increase distance between clusters
-    all_pcs3, all_labels3 = create_ground_truth_pc_distributions([1,-1],[1000, 100]) # decrease number of contaminating spikes
 
     isolation_distance1, l_ratio1 = mahalanobis_metrics(all_pcs1, all_labels1, 0)
     isolation_distance2, l_ratio2 = mahalanobis_metrics(all_pcs2, all_labels2, 0)
-    isolation_distance3, l_ratio3 = mahalanobis_metrics(all_pcs3, all_labels3, 0)
 
     assert isolation_distance1 < isolation_distance2
-    assert isolation_distance1 < isolation_distance3
-
     assert l_ratio1 > l_ratio2
 
 def test_lda_metrics():
@@ -120,8 +116,15 @@ def test_lda_metrics():
 
 def test_nearest_neighbors_metrics():
 
-    #hit_rate, miss_rate = nearest_neighbors_metrics(all_pcs, all_labels, 0, 1000, 3)
-    pass
+    all_pcs1, all_labels1 = create_ground_truth_pc_distributions([1,-1],[1000, 1000])
+    all_pcs2, all_labels2 = create_ground_truth_pc_distributions([1,-2],[1000, 1000]) # increase distance between clusters
+
+    hit_rate1, miss_rate1 = nearest_neighbors_metrics(all_pcs1, all_labels1, 0, 1000, 3)
+    hit_rate2, miss_rate2 = nearest_neighbors_metrics(all_pcs2, all_labels2, 0, 1000, 3)
+
+    assert hit_rate1 < hit_rate2
+    assert miss_rate1 > miss_rate2
+
 
 def test_calculate_silhouette_score():
     pass

--- a/spikemetrics/tests/test_metrics.py
+++ b/spikemetrics/tests/test_metrics.py
@@ -88,9 +88,47 @@ def test_calculate_metrics():
     
     pass
 
+def test_calculate_silhouette_score():
+
+    pc_features, spike_clusters = create_ground_truth_pc_distributions([1,-1, 10, 20],[1000, 1000, 500, 20])
+    pc_feature_ind = np.zeros((4,1),dtype='int')
+    total_units = 4
+    pc_features = np.expand_dims(pc_features, axis=2)
+
+    ss = calculate_silhouette_score(spike_clusters,
+                               total_units,
+                               pc_features,
+                               pc_feature_ind,
+                               1000,
+                               verbose=False)
+
+    assert np.sum(np.isnan(ss)) == 0
+
 
 def test_calculate_pc_metrics():
-    pass
+
+    pc_features, spike_clusters = create_ground_truth_pc_distributions([1,-1, 10, 20],[1000, 1000, 500, 20])
+    pc_feature_ind = np.zeros((4,1),dtype='int')
+    total_units = 4
+    pc_features = np.expand_dims(pc_features, axis=2)
+
+    isolation_distances, l_ratios, d_primes, nn_hit_rates, nn_miss_rates = \
+            calculate_pc_metrics(spike_clusters,
+                         total_units,
+                         pc_features,
+                         pc_feature_ind,
+                         1,
+                         500,
+                         1000,
+                         3,
+                         verbose=False)
+
+    assert np.sum(np.isnan(isolation_distances)) == 0
+    assert np.sum(np.isnan(l_ratios)) == 0
+    assert np.sum(np.isnan(d_primes)) == 0
+    assert np.sum(np.isnan(nn_hit_rates)) == 0
+    assert np.sum(np.isnan(nn_miss_rates)) == 0
+    
 
 def test_mahalanobis_metrics():
 
@@ -126,8 +164,7 @@ def test_nearest_neighbors_metrics():
     assert miss_rate1 > miss_rate2
 
 
-def test_calculate_silhouette_score():
-    pass
+
 
 @pytest.mark.parametrize(
     "num_total_spikes,num_selected_spikes",

--- a/spikemetrics/tests/test_metrics.py
+++ b/spikemetrics/tests/test_metrics.py
@@ -18,15 +18,6 @@ def test_calculate_drift_metrics():
     pass
 
 
-def test_calculate_firing_rate_and_spikes():
-    pass
-
-
-def test_calculate_isi_violations():
-
-    pass
-
-
 def test_calculate_pc_metrics():
     pass
 
@@ -42,6 +33,34 @@ def test_calculate_presence_ratio():
 def test_calculate_metrics():
     
     pass
+
+
+def test_calculate_firing_rate_and_spikes():
+    pass
+
+
+def test_calculate_isi_violations():
+
+    max_time = 100
+    train1 = simulated_spike_train(max_time, 10, 2)
+    train2 = simulated_spike_train(max_time, 5, 4)
+    train3 = simulated_spike_train(max_time, 5, 10)
+
+    labels1 = np.ones((train1.shape), dtype='int') * 0   
+    labels2 = np.ones((train2.shape), dtype='int') * 1
+    labels3 = np.ones((train3.shape), dtype='int') * 2
+
+    spike_times = np.concatenate((train1, train2, train3))
+    spike_clusters = np.concatenate((labels1, labels2, labels3))
+
+    order = np.argsort(spike_times)
+
+    spike_times = spike_times[order]
+    spike_clusters = spike_clusters[order]
+
+    viol = calculate_isi_violations(spike_times, spike_clusters, 3, 0.001, 0.0, verbose=False)
+
+    assert np.allclose(viol, array([0.0995016 , 0.78656463, 1.92041522]))
 
 
 def test_isi_violations():
@@ -97,5 +116,5 @@ def test_firing_rate():
 
     # 2. check that widening the boundaries decreases the rate:
 
-    assert firing_rate(train, min_time=0, max_time=100) > firing_rate(train, min_time=0, max_time =200)
+    assert firing_rate(train, min_time=0, max_time=100) > firing_rate(train, min_time=0, max_time=200)
 

--- a/spikemetrics/tests/test_metrics.py
+++ b/spikemetrics/tests/test_metrics.py
@@ -1,6 +1,13 @@
+import numpy as np
+
 from spikemetrics import calculate_amplitude_cutoff, calculate_drift_metrics, calculate_firing_rate_and_spikes, \
     calculate_isi_violations, calculate_pc_metrics, calculate_silhouette_score, calculate_presence_ratio, \
     calculate_metrics
+
+from spikemetrics.metrics import isi_violations, firing_rate
+
+from spikemetrics.tests.utils import simulated_spike_train
+
 
 
 def test_calculate_amplitude_cutoff():
@@ -16,6 +23,7 @@ def test_calculate_firing_rate_and_spikes():
 
 
 def test_calculate_isi_violations():
+
     pass
 
 
@@ -34,3 +42,60 @@ def test_calculate_presence_ratio():
 def test_calculate_metrics():
     
     pass
+
+
+def test_isi_violations():
+
+    # 1. check value for fixed spike train parameters:
+
+    train1 = simulated_spike_train(100, 10, 10)
+    fpRate1, num_violations1 = isi_violations(train1, 0, np.max(train1), 0.001)
+
+    assert np.isclose(fpRate1, 0.4901480247, rtol=0, atol=1e-5)
+    assert num_violations1 == 10
+
+
+    # 2. check that the value doesn't depend on recording duration:
+
+    train2 = simulated_spike_train(200, 10, 20)
+    fpRate2, num_violations2 = isi_violations(train2, 0, np.max(train2), 0.001)
+
+    assert np.isclose(fpRate1, fpRate2, rtol=0, atol=1e-5)
+
+
+    # 3. check that the value increases with the number of violations:
+
+    train3 = simulated_spike_train(100, 10, 20)
+    fpRate3, num_violations3 = isi_violations(train3, 0, np.max(train3), 0.001)
+
+    assert fpRate3 > fpRate1
+
+
+    # 4. check that the value decreases with a longer violation time:
+
+    fpRate4, num_violations4 = isi_violations(train1, 0, np.max(train1), 0.002)
+
+    assert fpRate4 < fpRate1
+
+
+    # 5. check that the value decreases with firing rate:
+
+    train4 = simulated_spike_train(100, 20, 10)
+    fpRate5, num_violations5 = isi_violations(train4, 0, np.max(train4), 0.001)
+
+    assert fpRate5 < fpRate1
+
+
+
+def test_firing_rate():
+
+    # 1. check that the output value is correct:
+
+    train = simulated_spike_train(100, 10, 0)
+
+    assert firing_rate(train, min_time=0, max_time=100) == 10.0
+
+    # 2. check that widening the boundaries decreases the rate:
+
+    assert firing_rate(train, min_time=0, max_time=100) > firing_rate(train, min_time=0, max_time =200)
+

--- a/spikemetrics/tests/test_utils.py
+++ b/spikemetrics/tests/test_utils.py
@@ -1,0 +1,17 @@
+import numpy as np
+import pytest
+
+from spikemetrics.utils import get_spike_depths
+from spikemetrics.tests.utils import simulated_pcs_for_one_spike
+
+
+def test_get_spike_depths():
+
+    peak_chan = 5
+
+    pc_features, pc_feature_ind = simulated_pcs_for_one_spike(32, peak_chan)
+    spike_clusters = np.ones((pc_features.shape[0],), dtype='int') * 0
+
+    depths = get_spike_depths(spike_clusters, pc_features, pc_feature_ind, vertical_channel_spacing=1)
+
+    assert np.isclose(depths, peak_chan, rtol=0, atol=1e-5)

--- a/spikemetrics/tests/utils.py
+++ b/spikemetrics/tests/utils.py
@@ -4,3 +4,30 @@ import numpy as np
 def create_ground_truth_pc_distributions():
     # HINT: start from Guassians in PC space and stereotyped waveforms and build dataset.
     pass
+
+
+def simulated_spike_train(duration, baseline_rate, num_violations, violation_delta=1e-5):
+    """ Create a spike train for testing ISI violations
+
+    Has uniform inter-spike intervals, except where violations occur
+
+    Input:
+    ------
+    duration : length of simulated recording (in seconds)
+    baseline_rate : firing rate for 'true' spikes
+    num_violations : number of contaminating spikes
+    violation_delta : temporal offset of contaminating spikes (in seconds)
+
+    Output:
+    -------
+    spike_train : array of monotonically increasing spike times
+
+    """
+
+    isis = np.ones((int(duration*baseline_rate),)) / baseline_rate
+    spike_train = np.cumsum(isis)
+    viol_times = spike_train[:int(num_violations)] + violation_delta
+    spike_train = np.sort(np.concatenate((spike_train, viol_times)))
+    
+    return spike_train
+    

--- a/spikemetrics/tests/utils.py
+++ b/spikemetrics/tests/utils.py
@@ -6,6 +6,59 @@ def create_ground_truth_pc_distributions():
     # HINT: start from Guassians in PC space and stereotyped waveforms and build dataset.
     pass
 
+def simulated_pcs_for_one_spike(total_channels, peak_channel):
+    """ Simulate the top principal components across channels for one spike
+
+    Used for testing drift metrics
+
+    Input:
+    ------
+    total_channels : number of channels
+    peak_channel : location of the peak channel
+
+    Output:
+    -------
+    pc_features : 1 x 3 x total_channels matrix of PC features
+    pc_feature_ind : channel indices for 3rd dimension of pc_features
+
+    """
+
+    pc_feature_ind = np.arange(total_channels)
+    feat = np.sqrt(norm.pdf(pc_feature_ind, loc=peak_channel, scale=1))
+    pc_features = np.zeros((1,3,32), dtype='float64')
+    pc_features[:,0,:] = feat.T
+
+    return pc_features, np.expand_dims(pc_feature_ind,axis=1).T
+
+
+def simulated_pcs_for_one_unit(num_spikes, total_channels, start_channel, end_channel):
+    """ Simulate the top principal components across channels for one unit
+
+    Used for testing drift metrics
+
+    Input:
+    ------
+    num_spikes : total number of spikes
+    total_channels : number of channels
+    start_channel : initial peak channel
+    end_channel : final peak channel
+
+    Output:
+    -------
+    spike_train : array of monotonically increasing spike times
+
+    """
+
+    pc_features = []
+
+    peak_channels = np.linspace(start_channel, end_channel, num_spikes)
+
+    for i, peak_chan in enumerate(peak_channels):
+        pc_feat, pc_feature_ind = simulated_pcs_for_one_spike(total_channels, peak_chan)
+        pc_features.append(pc_feat)
+
+    return np.concatenate(pc_features, axis=0)
+
 
 def simulated_spike_train(duration, baseline_rate, num_violations, violation_delta=1e-5):
     """ Create a spike train for testing ISI violations

--- a/spikemetrics/tests/utils.py
+++ b/spikemetrics/tests/utils.py
@@ -20,10 +20,11 @@ def create_ground_truth_pc_distributions(center_locations, total_points):
 
     """
 
+    np.random.seed(0)
+
     distributions = [multivariate_normal.rvs(mean=[center, 0.0, 0.0],
                                              cov=[1.0, 1.0, 1.0],
-                                             size=size,
-                                             seed=0) 
+                                             size=size) 
                     for center, size in zip(center_locations, total_points)]
 
     all_labels = np.concatenate([np.ones((distributions[i].shape[0],))*i  for i in range(len(distributions))])

--- a/spikemetrics/tests/utils.py
+++ b/spikemetrics/tests/utils.py
@@ -27,7 +27,7 @@ def create_ground_truth_pc_distributions(center_locations, total_points):
                                              size=size) 
                     for center, size in zip(center_locations, total_points)]
 
-    all_labels = np.concatenate([np.ones((distributions[i].shape[0],))*i  for i in range(len(distributions))])
+    all_labels = np.concatenate([np.ones((distributions[i].shape[0],),dtype='int')*i  for i in range(len(distributions))])
 
     all_pcs = np.concatenate(distributions, axis=0)
 

--- a/spikemetrics/tests/utils.py
+++ b/spikemetrics/tests/utils.py
@@ -1,5 +1,6 @@
 import numpy as np
 
+from scipy.stats import norm
 
 def create_ground_truth_pc_distributions():
     # HINT: start from Guassians in PC space and stereotyped waveforms and build dataset.
@@ -30,4 +31,28 @@ def simulated_spike_train(duration, baseline_rate, num_violations, violation_del
     spike_train = np.sort(np.concatenate((spike_train, viol_times)))
     
     return spike_train
+    
+
+def simulated_spike_amplitudes(num_spikes, mean_amplitude, amplitude_std):
+    """ Create spike amplitudes for testing amplitude cutoff
+
+    Has a Gaussian distribution, but may be truncated at the low end
+
+    Input:
+    ------
+    num_spikes : total_number of spikes
+    mean_amplitude : center of the amplitude histogram
+    amplitude_std : standard deviation of the amplitude histogram
+
+    Output:
+    -------
+    spike_amplitudes : array of amplitudes (arbitrary units)
+
+    """
+
+    np.random.seed(1)
+    r = norm.rvs(size=num_spikes, loc=mean_amplitude, scale=amplitude_std)
+    spike_amplitudes = np.delete(r, np.where(r < 0)[0])
+    
+    return spike_amplitudes
     

--- a/spikemetrics/tests/utils.py
+++ b/spikemetrics/tests/utils.py
@@ -1,10 +1,38 @@
 import numpy as np
 
-from scipy.stats import norm
+from scipy.stats import norm, multivariate_normal
 
-def create_ground_truth_pc_distributions():
-    # HINT: start from Guassians in PC space and stereotyped waveforms and build dataset.
-    pass
+def create_ground_truth_pc_distributions(center_locations, total_points):
+    """ Simulate PCs as multivariate Gaussians, for testing PC-based quality metrics
+
+    Values are created for only one channel and vary along one dimension
+
+    Input:
+    ------
+    separation : distance between distribution means
+    total_points : array indicating number of points in each distribution
+
+    Output:
+    -------
+    all_pcs : N x 3 matrix of simulated PCs
+        N = np.sum(total_points)
+    all_labels : array of cluster IDs
+
+    """
+
+    distributions = [multivariate_normal.rvs(mean=[center, 0.0, 0.0],
+                                             cov=[1.0, 1.0, 1.0],
+                                             size=size,
+                                             seed=0) 
+                    for center, size in zip(center_locations, total_points)]
+
+    all_labels = np.concatenate([np.ones((distributions[i].shape[0],))*i  for i in range(len(distributions))])
+
+    all_pcs = np.concatenate(distributions, axis=0)
+
+    return all_pcs, all_labels
+    
+
 
 def simulated_pcs_for_one_spike(total_channels, peak_channel):
     """ Simulate the top principal components across channels for one spike

--- a/spikemetrics/utils.py
+++ b/spikemetrics/utils.py
@@ -373,9 +373,12 @@ def load_kilosort_data(folder,
         return spike_times, spike_clusters, spike_templates, amplitudes, unwhitened_temps, channel_map, cluster_ids, cluster_quality, pc_features, pc_feature_ind
 
 
-def get_spike_depths(spike_clusters, pc_features, pc_feature_ind):
+def get_spike_depths(spike_clusters, pc_features, pc_feature_ind, vertical_channel_spacing=10):
     """
     Calculates the distance (in microns) of individual spikes from the probe tip
+
+    Assumes a linear channel layout, and equal vertical spacing between channels;
+    for a Neuropixels probe, it does not account for the fact
 
     This implementation is based on Matlab code from github.com/cortex-lab/spikes
 
@@ -387,6 +390,8 @@ def get_spike_depths(spike_clusters, pc_features, pc_feature_ind):
         PC features for each spike
     pc_feature_ind  : numpy.ndarray (M x channels)
         Channels used for PC calculation for each unit
+    vertical_channel_spacing : float
+        Vertical channel spacing in microns (assumed to be equal for all channels)
 
     Output:
     ------
@@ -395,13 +400,13 @@ def get_spike_depths(spike_clusters, pc_features, pc_feature_ind):
 
     """
     pc_features_drift = np.copy(pc_features)
-    pc_features_drift = np.squeeze(pc_features_drift[:, 0, :])
+    pc_features_drift = pc_features_drift[:, 0, :]
     pc_features_drift[pc_features_drift < 0] = 0
     pc_power = pow(pc_features_drift, 2)
     spike_feat_ind = pc_feature_ind[spike_clusters, :]
-    spike_depths = np.sum(spike_feat_ind * pc_power) / np.sum(pc_power, 1)
+    spike_depths = np.sum(spike_feat_ind * pc_power, 1) / np.sum(pc_power, 1)
 
-    return spike_depths * 10
+    return spike_depths * vertical_channel_spacing
 
 
 def get_spike_amplitudes(spike_templates, templates, amplitudes):


### PR DESCRIPTION
These changes add unit tests for all of the metrics. We're still missing tests for the main `calculate_metrics` function, as well as most of the utility functions.

In the process of writing the tests, I found a mistake in the `silhouette_score` calculation. It was returning the minimum along only one axis, which meant that many of the potential comparisons were not taken into account. This error has been corrected now.