### PR TITLE
removed spike count from metrics, will make my own version

### DIFF
--- a/spikemetrics/__init__.py
+++ b/spikemetrics/__init__.py
@@ -1,4 +1,4 @@
-from .metrics import calculate_amplitude_cutoff, calculate_drift_metrics, calculate_firing_rate_and_spikes, \
+from .metrics import calculate_amplitude_cutoff, calculate_drift_metrics, calculate_firing_rates, \
     calculate_isi_violations, calculate_pc_metrics, calculate_silhouette_score, calculate_presence_ratio, \
     calculate_metrics
 from .utils import Epoch, printProgressBar 

--- a/spikemetrics/metrics.py
+++ b/spikemetrics/metrics.py
@@ -77,8 +77,8 @@ def calculate_metrics(spike_times, spike_clusters, amplitudes, pc_features, pc_f
                                                   duration, verbose=verbose)
 
         print("Calculating firing rate")
-        firing_rate, num_spikes = calculate_firing_rate_and_spikes(spike_times[in_epoch], spike_clusters[in_epoch],
-                                                                   duration, total_units, verbose=verbose)
+        firing_rate = calculate_firing_rates(spike_times[in_epoch], spike_clusters[in_epoch],
+                                             duration, total_units, verbose=verbose)
 
         print("Calculating amplitude cutoff")
         amplitude_cutoff = calculate_amplitude_cutoff(spike_clusters[in_epoch], amplitudes[in_epoch], total_units,
@@ -123,7 +123,6 @@ def calculate_metrics(spike_times, spike_clusters, amplitudes, pc_features, pc_f
         epoch_name = [epoch.name] * len(cluster_ids_out)
 
         metrics = pd.concat((metrics, pd.DataFrame(data=OrderedDict((('cluster_id', cluster_ids_out),
-                                                                     ('num_spikes', num_spikes),
                                                                      ('firing_rate', firing_rate),
                                                                      ('presence_ratio', presence_ratio),
                                                                      ('isi_viol', isi_viol),
@@ -184,11 +183,9 @@ def calculate_presence_ratio(spike_times, spike_clusters, total_units, duration,
     return ratios
 
 
-def calculate_firing_rate_and_spikes(spike_times, spike_clusters, total_units, duration, verbose=True):
+def calculate_firing_rates(spike_times, spike_clusters, total_units, duration, verbose=True):
     cluster_ids = np.unique(spike_clusters)
-
     firing_rates = np.zeros((total_units,))
-    num_spikes = np.zeros((total_units,))
 
     for idx, cluster_id in enumerate(cluster_ids):
 
@@ -198,9 +195,8 @@ def calculate_firing_rate_and_spikes(spike_times, spike_clusters, total_units, d
         for_this_cluster = (spike_clusters == cluster_id)
         firing_rates[cluster_id] = firing_rate(spike_times[for_this_cluster],
                                                duration=duration)
-        num_spikes[cluster_id] = len(spike_times[for_this_cluster])
 
-    return firing_rates, num_spikes
+    return firing_rates
 
 
 def calculate_amplitude_cutoff(spike_clusters, amplitudes, total_units, verbose=True):

--- a/spikemetrics/tests/test_metrics.py
+++ b/spikemetrics/tests/test_metrics.py
@@ -3,7 +3,7 @@ import pytest
 
 from spikemetrics import (calculate_amplitude_cutoff, 
                           calculate_drift_metrics, 
-                          calculate_firing_rate_and_spikes, 
+                          calculate_firing_rates, 
                           calculate_isi_violations, 
                           calculate_pc_metrics, 
                           calculate_silhouette_score, 
@@ -332,13 +332,12 @@ def test_isi_violations():
 
 
 
-def test_calculate_firing_rate_and_spikes(simulated_spike_times):
+def test_calculate_firing_rate(simulated_spike_times):
 
-    firing_rates, spike_counts = calculate_firing_rate_and_spikes(simulated_spike_times['spike_times'], 
-                                    simulated_spike_times['spike_clusters'], 
-                                    3, duration=simulated_spike_times['spike_times'][-1], verbose=False)
+    firing_rates = calculate_firing_rates(simulated_spike_times['spike_times'], 
+                                                        simulated_spike_times['spike_clusters'], 
+                                                        3, duration=simulated_spike_times['spike_times'][-1], verbose=False)
     assert np.allclose(firing_rates, np.array([10.02,   5.04,  5.1]))
-    assert np.allclose(spike_counts, np.array([1002, 504, 510]))
 
 
 def test_firing_rate():


### PR DESCRIPTION
As above, I think I will make a spikeinterface version of num_spikes since then I don't need to pass in duration. Also, it is cleaner.