### PR TITLE
Implement get_spike_depth using center of mass

### DIFF
--- a/spikemetrics/metrics.py
+++ b/spikemetrics/metrics.py
@@ -15,7 +15,7 @@ from scipy.stats import chi2
 from scipy.ndimage.filters import gaussian_filter1d
 
 from .utils import Epoch
-from .utils import printProgressBar, get_spike_depths
+from .utils import printProgressBar, get_spike_positions
 
 
 def calculate_metrics(spike_times, spike_clusters, amplitudes, pc_features, pc_feature_ind, params,
@@ -449,7 +449,8 @@ def calculate_drift_metrics(spike_times,
     max_drift = np.zeros((total_units,))
     cumulative_drift = np.zeros((total_units,))
 
-    positions = get_spike_depths(spike_clusters, pc_features, pc_feature_ind, channel_locations)
+    positions = get_spike_positions(spike_clusters, pc_features, pc_feature_ind, channel_locations,
+                                    vertical_channel_spacing)
     interval_starts = np.arange(np.min(spike_times), np.max(spike_times), interval_length)
     interval_ends = interval_starts + interval_length
 
@@ -496,6 +497,7 @@ def calculate_drift_metrics(spike_times,
             # Summing them up we obtain cumulative drift
             cumulative_drift[cluster_id] = np.around(np.sum(np.diag(position_diffs, 1)), 2)
         else:
+            # not enough spikes
             max_drift[cluster_id] = 0
             cumulative_drift[cluster_id] = 0
 

--- a/spikemetrics/metrics.py
+++ b/spikemetrics/metrics.py
@@ -442,13 +442,14 @@ def calculate_drift_metrics(spike_times,
                             interval_length,
                             min_spikes_per_interval,
                             vertical_channel_spacing=10,
-                            spike_cluster_subset=None, 
+                            channel_locations=None,
+                            spike_cluster_subset=None,
                             verbose=True):
 
     max_drift = np.zeros((total_units,))
     cumulative_drift = np.zeros((total_units,))
 
-    depths = get_spike_depths(spike_clusters, pc_features, pc_feature_ind, vertical_channel_spacing)
+    positions = get_spike_depths(spike_clusters, pc_features, pc_feature_ind, channel_locations)
     interval_starts = np.arange(np.min(spike_times), np.max(spike_times), interval_length)
     interval_ends = interval_starts + interval_length
 
@@ -464,23 +465,39 @@ def calculate_drift_metrics(spike_times,
 
         in_cluster = spike_clusters == cluster_id
         times_for_cluster = spike_times[in_cluster]
-        depths_for_cluster = depths[in_cluster]
+        positions_for_cluster = positions[in_cluster]
 
-        median_depths = []
+        median_positions = []
 
         for t1, t2 in zip(interval_starts, interval_ends):
-
             in_range = (times_for_cluster > t1) * (times_for_cluster < t2)
 
             if np.sum(in_range) >= min_spikes_per_interval:
-                median_depths.append(np.median(depths_for_cluster[in_range]))
+                median_positions.append(np.median(positions_for_cluster[in_range], 0))
             else:
-                median_depths.append(np.nan)
+                median_positions.append([np.nan, np.nan])
 
-        median_depths = np.array(median_depths)
+        median_positions = np.array(median_positions)
 
-        max_drift[cluster_id] = np.around(np.nanmax(median_depths) - np.nanmin(median_depths), 2)
-        cumulative_drift[cluster_id] = np.around(np.nansum(np.abs(np.diff(median_depths))), 2)
+        # Extract emi-matrix of shifts in positions (used to extract max_drift and cum_drift)
+        position_diffs = np.zeros((len(median_positions), len(median_positions)))
+        for i, pos_i in enumerate(median_positions):
+            for j, pos_j in enumerate(median_positions):
+                if j > i:
+                    if not np.isnan(pos_i[0]) and not np.isnan(pos_j[0]):
+                        position_diffs[i, j] = np.linalg.norm(pos_i - pos_j)
+                    else:
+                        position_diffs[i, j] = 0
+
+        # Maximum drift among all periods
+        if np.any(position_diffs > 0):
+            max_drift[cluster_id] = np.around(np.max(position_diffs[position_diffs > 0]), 2)
+            # The +1 diagonal contains the step-by-step drifts between intervals.
+            # Summing them up we obtain cumulative drift
+            cumulative_drift[cluster_id] = np.around(np.sum(np.diag(position_diffs, 1)), 2)
+        else:
+            max_drift[cluster_id] = 0
+            cumulative_drift[cluster_id] = 0
 
     return max_drift, cumulative_drift
 

--- a/spikemetrics/tests/test_metrics.py
+++ b/spikemetrics/tests/test_metrics.py
@@ -1,20 +1,19 @@
 import numpy as np
 import pytest
 
-from spikemetrics import (calculate_amplitude_cutoff, 
-                          calculate_drift_metrics, 
-                          calculate_firing_rates, 
-                          calculate_isi_violations, 
-                          calculate_pc_metrics, 
-                          calculate_silhouette_score, 
-                          calculate_presence_ratio, 
+from spikemetrics import (calculate_amplitude_cutoff,
+                          calculate_drift_metrics,
+                          calculate_firing_rates,
+                          calculate_isi_violations,
+                          calculate_pc_metrics,
+                          calculate_silhouette_score,
+                          calculate_presence_ratio,
                           calculate_metrics,
                           calculate_num_spikes)
-                          
 
-from spikemetrics.metrics import (isi_violations, 
-                                  firing_rate, 
-                                  presence_ratio, 
+from spikemetrics.metrics import (isi_violations,
+                                  firing_rate,
+                                  presence_ratio,
                                   amplitude_cutoff,
                                   mahalanobis_metrics,
                                   lda_metrics,
@@ -23,14 +22,14 @@ from spikemetrics.metrics import (isi_violations,
                                   make_channel_mask,
                                   get_unit_pcs)
 
-from spikemetrics.tests.utils import (simulated_spike_train, 
+from spikemetrics.tests.utils import (simulated_spike_train,
                                       simulated_spike_amplitudes,
                                       simulated_pcs_for_one_unit,
                                       create_ground_truth_pc_distributions)
 
+
 @pytest.fixture
 def simulated_spike_times():
-
     max_time = 100
 
     trains = [simulated_spike_train(max_time, 10, 2),
@@ -47,11 +46,11 @@ def simulated_spike_times():
     spike_times = spike_times[order]
     spike_clusters = spike_clusters[order]
 
-    return {'spike_times' : spike_times, 'spike_clusters' : spike_clusters}
+    return {'spike_times': spike_times, 'spike_clusters': spike_clusters}
+
 
 @pytest.fixture
 def simulated_amplitudes():
-
     num_spikes = 5000
 
     amps = [simulated_spike_amplitudes(num_spikes, center, 30) for center in [100, 50, 20, 5]]
@@ -61,81 +60,78 @@ def simulated_amplitudes():
     spike_amplitudes = np.concatenate(amps)
     spike_clusters = np.concatenate(labels)
 
-    return {'spike_amplitudes' : spike_amplitudes, 'spike_clusters' : spike_clusters}
+    return {'spike_amplitudes': spike_amplitudes, 'spike_clusters': spike_clusters}
 
 
 @pytest.fixture
 def simulated_drift_pcs():
-
     num_spikes = 5000
 
     pc_features = [simulated_pcs_for_one_unit(num_spikes, 32, 5, end_channel) for end_channel in [5, 10, 15, 20]]
 
     labels = [np.ones((pc_features[i].shape[0],), dtype='int') * i for i in range(len(pc_features))]
-    times = [np.linspace(0, 100, pc_features[i].shape[0],) for i in range(len(pc_features))]
-    
-    pc_feature_ind = np.tile(np.arange(32, dtype='int'), (len(pc_features),1))
+    times = [np.linspace(0, 100, pc_features[i].shape[0], ) for i in range(len(pc_features))]
+
+    pc_feature_ind = np.tile(np.arange(32, dtype='int'), (len(pc_features), 1))
 
     pc_features = np.concatenate(pc_features, axis=0)
     spike_clusters = np.concatenate(labels)
     spike_times = np.concatenate(times)
 
-    return {'pc_features' : pc_features, 
-            'pc_feature_ind' : pc_feature_ind,
-            'spike_clusters' : spike_clusters,
-            'spike_times' : spike_times}
+    return {'pc_features': pc_features,
+            'pc_feature_ind': pc_feature_ind,
+            'spike_clusters': spike_clusters,
+            'spike_times': spike_times}
 
 
 def test_calculate_metrics():
-    
     pass
 
-def test_calculate_silhouette_score():
 
-    pc_features, spike_clusters = create_ground_truth_pc_distributions([1,-1, 10, 20],[1000, 1000, 500, 20])
-    pc_feature_ind = np.zeros((4,1),dtype='int')
+def test_calculate_silhouette_score():
+    pc_features, spike_clusters = create_ground_truth_pc_distributions([1, -1, 10, 20], [1000, 1000, 500, 20])
+    pc_feature_ind = np.zeros((4, 1), dtype='int')
     total_units = 4
     pc_features = np.expand_dims(pc_features, axis=2)
 
     ss = calculate_silhouette_score(spike_clusters,
-                               total_units,
-                               pc_features,
-                               pc_feature_ind,
-                               1000,
-                               verbose=False)
+                                    total_units,
+                                    pc_features,
+                                    pc_feature_ind,
+                                    1000,
+                                    verbose=False)
 
     assert np.sum(np.isnan(ss)) == 0
 
 
 def test_calculate_pc_metrics():
-
-    pc_features, spike_clusters = create_ground_truth_pc_distributions([1,-1, 10, 20],[1000, 1000, 500, 20])
-    pc_feature_ind = np.zeros((4,1),dtype='int')
+    pc_features, spike_clusters = create_ground_truth_pc_distributions([1, -1, 10, 20], [1000, 1000, 500, 20])
+    pc_feature_ind = np.zeros((4, 1), dtype='int')
     total_units = 4
     pc_features = np.expand_dims(pc_features, axis=2)
 
     isolation_distances, l_ratios, d_primes, nn_hit_rates, nn_miss_rates = \
-            calculate_pc_metrics(spike_clusters,
-                         total_units,
-                         pc_features,
-                         pc_feature_ind,
-                         1,
-                         500,
-                         1000,
-                         3,
-                         verbose=False)
+        calculate_pc_metrics(spike_clusters,
+                             total_units,
+                             pc_features,
+                             pc_feature_ind,
+                             1,
+                             500,
+                             1000,
+                             3,
+                             verbose=False)
 
     assert np.sum(np.isnan(isolation_distances)) == 0
     assert np.sum(np.isnan(l_ratios)) == 0
     assert np.sum(np.isnan(d_primes)) == 0
     assert np.sum(np.isnan(nn_hit_rates)) == 0
     assert np.sum(np.isnan(nn_miss_rates)) == 0
-    
+
 
 def test_mahalanobis_metrics():
-
-    all_pcs1, all_labels1 = create_ground_truth_pc_distributions([1,-1],[1000, 1000])
-    all_pcs2, all_labels2 = create_ground_truth_pc_distributions([1,-2],[1000, 1000]) # increase distance between clusters
+    all_pcs1, all_labels1 = create_ground_truth_pc_distributions([1, -1], [1000, 1000])
+    all_pcs2, all_labels2 = create_ground_truth_pc_distributions([1, -2],
+                                                                 [1000, 1000])  # increase distance between clusters
 
     isolation_distance1, l_ratio1 = mahalanobis_metrics(all_pcs1, all_labels1, 0)
     isolation_distance2, l_ratio2 = mahalanobis_metrics(all_pcs2, all_labels2, 0)
@@ -143,10 +139,11 @@ def test_mahalanobis_metrics():
     assert isolation_distance1 < isolation_distance2
     assert l_ratio1 > l_ratio2
 
-def test_lda_metrics():
 
-    all_pcs1, all_labels1 = create_ground_truth_pc_distributions([1,-1],[1000, 1000])
-    all_pcs2, all_labels2 = create_ground_truth_pc_distributions([1,-2],[1000, 1000]) # increase distance between clusters
+def test_lda_metrics():
+    all_pcs1, all_labels1 = create_ground_truth_pc_distributions([1, -1], [1000, 1000])
+    all_pcs2, all_labels2 = create_ground_truth_pc_distributions([1, -2],
+                                                                 [1000, 1000])  # increase distance between clusters
 
     d_prime1 = lda_metrics(all_pcs1, all_labels1, 0)
     d_prime2 = lda_metrics(all_pcs2, all_labels2, 0)
@@ -155,17 +152,15 @@ def test_lda_metrics():
 
 
 def test_nearest_neighbors_metrics():
-
-    all_pcs1, all_labels1 = create_ground_truth_pc_distributions([1,-1],[1000, 1000])
-    all_pcs2, all_labels2 = create_ground_truth_pc_distributions([1,-2],[1000, 1000]) # increase distance between clusters
+    all_pcs1, all_labels1 = create_ground_truth_pc_distributions([1, -1], [1000, 1000])
+    all_pcs2, all_labels2 = create_ground_truth_pc_distributions([1, -2],
+                                                                 [1000, 1000])  # increase distance between clusters
 
     hit_rate1, miss_rate1 = nearest_neighbors_metrics(all_pcs1, all_labels1, 0, 1000, 3)
     hit_rate2, miss_rate2 = nearest_neighbors_metrics(all_pcs2, all_labels2, 0, 1000, 3)
 
     assert hit_rate1 < hit_rate2
     assert miss_rate1 > miss_rate2
-
-
 
 
 @pytest.mark.parametrize(
@@ -175,31 +170,29 @@ def test_nearest_neighbors_metrics():
     ],
 )
 def test_make_index_mask(num_total_spikes, num_selected_spikes):
-
     spike_clusters = np.ones((num_total_spikes,), dtype='int')
     unit_id = 1
 
     index_mask = make_index_mask(spike_clusters, unit_id, 200, 500, seed=0)
 
     assert np.sum(index_mask) == num_selected_spikes
-                                  
+
 
 def test_make_channel_mask():
-
     pc_feature_ind = np.tile(np.arange(32), (4, 1))
-    pc_feature_ind[0,:] = pc_feature_ind[0,np.random.permutation(32)]
+    pc_feature_ind[0, :] = pc_feature_ind[0, np.random.permutation(32)]
     unit_id = 0
     channels_to_use = np.arange(10)
 
     channel_mask = make_channel_mask(unit_id, pc_feature_ind, channels_to_use)
 
     sorted_channel_mask = np.sort(channel_mask)
-    expected_result = np.where(np.isin(pc_feature_ind[unit_id,:], channels_to_use))[0]
- 
+    expected_result = np.where(np.isin(pc_feature_ind[unit_id, :], channels_to_use))[0]
+
     assert np.array_equal(sorted_channel_mask, expected_result)
 
-def test_get_unit_pcs():
 
+def test_get_unit_pcs():
     original_spike_count = 1000
     masked_spike_count = 100
 
@@ -209,7 +202,7 @@ def test_get_unit_pcs():
     num_pc_features = 3
 
     these_pc_features = np.ones((original_spike_count, num_pc_features, original_channel_count))
-    
+
     channel_mask = np.arange(masked_channel_count)
     index_mask = np.zeros((original_spike_count,), dtype='bool')
     index_mask[:masked_spike_count] = True
@@ -219,36 +212,30 @@ def test_get_unit_pcs():
     assert unit_PCs.shape == (masked_spike_count, num_pc_features, masked_channel_count)
 
 
-
-
-
-
 def test_calculate_drift_metrics(simulated_drift_pcs):
-
     max_drift, cumulative_drift = calculate_drift_metrics(simulated_drift_pcs['spike_times'],
-                            simulated_drift_pcs['spike_clusters'],
-                            4,
-                            simulated_drift_pcs['pc_features'],
-                            simulated_drift_pcs['pc_feature_ind'],
-                            10,1,1)
+                                                          simulated_drift_pcs['spike_clusters'],
+                                                          4,
+                                                          simulated_drift_pcs['pc_features'],
+                                                          simulated_drift_pcs['pc_feature_ind'],
+                                                          10, 1, 1)
+
+    # TODO add test with locations
 
     assert np.allclose(max_drift, np.array([0, 4.5, 9, 13.5]))
     assert np.allclose(cumulative_drift, np.array([0, 4.5, 9, 13.5]))
 
 
 def test_calculate_amplitude_cutoff(simulated_amplitudes):
-
-
-    amp_cuts = calculate_amplitude_cutoff(simulated_amplitudes['spike_clusters'], 
-                                          simulated_amplitudes['spike_amplitudes'], 
-                                          4, 
+    amp_cuts = calculate_amplitude_cutoff(simulated_amplitudes['spike_clusters'],
+                                          simulated_amplitudes['spike_amplitudes'],
+                                          4,
                                           verbose=False)
 
     assert np.allclose(amp_cuts, np.array([0.0015467, 0.03828989, 0.36565474, 0.5]), rtol=0, atol=1e-5)
 
 
-def test_amplitude_cutoff(): 
-
+def test_amplitude_cutoff():
     amplitudes = simulated_spike_amplitudes(5000, 100, 30)
 
     amp_cut = amplitude_cutoff(amplitudes)
@@ -256,13 +243,12 @@ def test_amplitude_cutoff():
     assert np.isclose(amp_cut, 0.001546, rtol=0, atol=1e-5)
 
 
-
 def test_calculate_presence_ratio(simulated_spike_times):
-    ratios = calculate_presence_ratio(simulated_spike_times['spike_times'], 
-                                    simulated_spike_times['spike_clusters'], 
-                                    3,
-                                    duration=simulated_spike_times['spike_times'][-1],
-                                    verbose=False)
+    ratios = calculate_presence_ratio(simulated_spike_times['spike_times'],
+                                      simulated_spike_times['spike_clusters'],
+                                      3,
+                                      duration=simulated_spike_times['spike_times'][-1],
+                                      verbose=False)
 
     assert np.allclose(ratios, np.array([1.0, 1.0, 1.0]))
 
@@ -274,24 +260,19 @@ def test_calculate_presence_ratio(simulated_spike_times):
     ],
 )
 def test_presence_ratio(overall_duration, expected_value):
-
     spike_times = simulated_spike_train(100, 20, 0)
 
     assert presence_ratio(spike_times, overall_duration) == expected_value
 
 
-
-
 def test_calculate_isi_violations(simulated_spike_times):
-
-    viol = calculate_isi_violations(simulated_spike_times['spike_times'], 
-                                    simulated_spike_times['spike_clusters'], 
+    viol = calculate_isi_violations(simulated_spike_times['spike_times'],
+                                    simulated_spike_times['spike_clusters'],
                                     3, 0.001, 0.0, duration=simulated_spike_times['spike_times'][-1], verbose=False)
-    assert np.allclose(viol, np.array([0.0996012 , 0.78735198, 1.92233756]))
+    assert np.allclose(viol, np.array([0.0996012, 0.78735198, 1.92233756]))
 
 
 def test_isi_violations():
-
     # 1. check value for fixed spike train parameters:
 
     train1 = simulated_spike_train(100, 10, 10)
@@ -300,14 +281,12 @@ def test_isi_violations():
     assert np.isclose(fpRate1, 0.4901480247, rtol=0, atol=1e-5)
     assert num_violations1 == 10
 
-
     # 2. check that the value doesn't depend on recording duration:
 
     train2 = simulated_spike_train(200, 10, 20)
     fpRate2, num_violations2 = isi_violations(train2, np.max(train2), 0.001)
 
     assert np.isclose(fpRate1, fpRate2, rtol=0, atol=1e-5)
-
 
     # 3. check that the value increases with the number of violations:
 
@@ -316,13 +295,11 @@ def test_isi_violations():
 
     assert fpRate3 > fpRate1
 
-
     # 4. check that the value decreases with a longer violation window:
 
     fpRate4, num_violations4 = isi_violations(train1, np.max(train1), 0.002)
 
     assert fpRate4 < fpRate1
-
 
     # 5. check that the value decreases with firing rate:
 
@@ -332,21 +309,18 @@ def test_isi_violations():
     assert fpRate5 < fpRate1
 
 
-
 def test_calculate_firing_rate_num_spikes(simulated_spike_times):
-
-    firing_rates = calculate_firing_rates(simulated_spike_times['spike_times'], 
-                                          simulated_spike_times['spike_clusters'], 
+    firing_rates = calculate_firing_rates(simulated_spike_times['spike_times'],
+                                          simulated_spike_times['spike_clusters'],
                                           3, duration=simulated_spike_times['spike_times'][-1], verbose=False)
-    num_spikes = calculate_num_spikes(simulated_spike_times['spike_times'], 
-                                      simulated_spike_times['spike_clusters'], 
+    num_spikes = calculate_num_spikes(simulated_spike_times['spike_times'],
+                                      simulated_spike_times['spike_clusters'],
                                       3, verbose=False)
-    assert np.allclose(firing_rates, np.array([10.02,   5.04,  5.1]))
+    assert np.allclose(firing_rates, np.array([10.02, 5.04, 5.1]))
     assert np.allclose(num_spikes, np.array([1002, 504, 510]))
 
 
 def test_firing_rate():
-
     # 1. check that the output value is correct:
 
     max_time = 100
@@ -359,4 +333,3 @@ def test_firing_rate():
     # 2. check that widening the boundaries decreases the rate:
 
     assert firing_rate(train, duration=100) > firing_rate(train, duration=200)
-

--- a/spikemetrics/tests/test_metrics.py
+++ b/spikemetrics/tests/test_metrics.py
@@ -218,9 +218,9 @@ def test_calculate_drift_metrics(simulated_drift_pcs):
                                                           4,
                                                           simulated_drift_pcs['pc_features'],
                                                           simulated_drift_pcs['pc_feature_ind'],
-                                                          10, 1, 1)
-
-    # TODO add test with locations
+                                                          interval_length=10,
+                                                          min_spikes_per_interval=1, vertical_channel_spacing=1,
+                                                          channel_locations=None)
 
     assert np.allclose(max_drift, np.array([0, 4.5, 9, 13.5]))
     assert np.allclose(cumulative_drift, np.array([0, 4.5, 9, 13.5]))

--- a/spikemetrics/tests/test_utils.py
+++ b/spikemetrics/tests/test_utils.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 
-from spikemetrics.utils import get_spike_depths
+from spikemetrics.utils import get_spike_positions
 from spikemetrics.tests.utils import simulated_pcs_for_one_spike
 
 
@@ -12,6 +12,7 @@ def test_get_spike_depths():
     pc_features, pc_feature_ind = simulated_pcs_for_one_spike(32, peak_chan)
     spike_clusters = np.ones((pc_features.shape[0],), dtype='int') * 0
 
-    depths = get_spike_depths(spike_clusters, pc_features, pc_feature_ind, vertical_channel_spacing=1)
+    positions = get_spike_positions(spike_clusters, pc_features, pc_feature_ind, vertical_channel_spacing=1)
+    depths = positions[:, 1]
 
     assert np.isclose(depths, peak_chan, rtol=0, atol=1e-5)

--- a/spikemetrics/utils.py
+++ b/spikemetrics/utils.py
@@ -373,11 +373,12 @@ def load_kilosort_data(folder,
         return spike_times, spike_clusters, spike_templates, amplitudes, unwhitened_temps, channel_map, cluster_ids, cluster_quality, pc_features, pc_feature_ind
 
 
-def get_spike_depths(spike_clusters, pc_features, pc_feature_ind, channel_locations=None, vertical_channel_spacing=10):
+def get_spike_positions(spike_clusters, pc_features, pc_feature_ind, channel_locations=None,
+                        vertical_channel_spacing=10):
     """
-    Calculates the distance (in microns) of individual spikes
+    Calculates the estimated position (in microns - x, y) of individual spikes
 
-    If channel locations are not used, it ssumes a linear channel layout, and equal vertical spacing between channels;
+    If channel_locations are not used, it assumes a linear channel layout, and equal vertical spacing between channels;
     for a Neuropixels probe, it does not account for the fact that the probe is staggered.
 
     This implementation is based on Matlab code from github.com/cortex-lab/spikes

--- a/spikemetrics/utils.py
+++ b/spikemetrics/utils.py
@@ -373,12 +373,12 @@ def load_kilosort_data(folder,
         return spike_times, spike_clusters, spike_templates, amplitudes, unwhitened_temps, channel_map, cluster_ids, cluster_quality, pc_features, pc_feature_ind
 
 
-def get_spike_depths(spike_clusters, pc_features, pc_feature_ind, vertical_channel_spacing=10):
+def get_spike_depths(spike_clusters, pc_features, pc_feature_ind, channel_locations=None, vertical_channel_spacing=10):
     """
-    Calculates the distance (in microns) of individual spikes from the probe tip
+    Calculates the distance (in microns) of individual spikes
 
-    Assumes a linear channel layout, and equal vertical spacing between channels;
-    for a Neuropixels probe, it does not account for the fact
+    If channel locations are not used, it ssumes a linear channel layout, and equal vertical spacing between channels;
+    for a Neuropixels probe, it does not account for the fact that the probe is staggered.
 
     This implementation is based on Matlab code from github.com/cortex-lab/spikes
 
@@ -390,6 +390,8 @@ def get_spike_depths(spike_clusters, pc_features, pc_feature_ind, vertical_chann
         PC features for each spike
     pc_feature_ind  : numpy.ndarray (M x channels)
         Channels used for PC calculation for each unit
+    channel_locations: numpy.ndarray (num_channels x 2)
+        Locations of all channels of the probe. If None, vertical_channel_spacing is used
     vertical_channel_spacing : float
         Vertical channel spacing in microns (assumed to be equal for all channels)
 
@@ -400,13 +402,19 @@ def get_spike_depths(spike_clusters, pc_features, pc_feature_ind, vertical_chann
 
     """
     pc_features_drift = np.copy(pc_features)
-    pc_features_drift = pc_features_drift[:, 0, :]
+    pc_features_drift = pc_features_drift[:, 0, :]  # ????
     pc_features_drift[pc_features_drift < 0] = 0
     pc_power = pow(pc_features_drift, 2)
     spike_feat_ind = pc_feature_ind[spike_clusters, :]
-    spike_depths = np.sum(spike_feat_ind * pc_power, 1) / np.sum(pc_power, 1)
+    if channel_locations is not None:
+        com = np.array([np.sum((channel_locations[spike_feat_ind][:, :, 0] * pc_power), 1) / np.sum(pc_power, 1),
+                        np.sum((channel_locations[spike_feat_ind][:, :, 1] * pc_power), 1) / np.sum(pc_power, 1)]).T
+    else:
+        spike_depths = np.sum(spike_feat_ind * pc_power, 1) / np.sum(pc_power, 1)
+        com = np.zeros((len(pc_features_drift), 2))
+        com[:, 1] = spike_depths * vertical_channel_spacing
 
-    return spike_depths * vertical_channel_spacing
+    return com
 
 
 def get_spike_amplitudes(spike_templates, templates, amplitudes):


### PR DESCRIPTION
Use the channel positions to compute an estimate of the spike position using the center of mass.

Changhed drift metrics computation accordingly.

- [x] update tests

Here is a notebook showing the performance with MEArec recordings with slow and fast drifts: https://gist.github.com/alejoe91/3f1672beb752eaed8997e2c4961990af

@jsiegle @colehurwitz 
